### PR TITLE
Allow endpoint to crash, without compromising future flush

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -2,5 +2,6 @@
   "port":     "9187",
   "host":     "localhost",
   "interval": 60,
-  "endpoint": "http://www.example.com/internal/save_hits"
+  "endpoint": "http://www.example.com/internal/save_hits",
+  "discard": true
 }

--- a/index.html
+++ b/index.html
@@ -198,7 +198,8 @@ pixel-ping path/to/config.json</pre>
   "host":     "127.0.0.1",
   "port":     "9187",
   "interval": 600,
-  "endpoint": "http://www.example.com/internal/save_hits"
+  "endpoint": "http://www.example.com/internal/save_hits",
+  "discard": false
 }</pre>
 
     <h2 id="changes">Change Log</h2>

--- a/lib/pixel-ping.js
+++ b/lib/pixel-ping.js
@@ -1,5 +1,5 @@
 (function() {
-  var VERSION, config, configPath, emptyHeaders, endHeaders, endParams, endpoint, flush, fs, http, log, pixel, pixelHeaders, querystring, record, serialize, server, store, url;
+  var VERSION, config, configPath, emptyHeaders, endHeaders, endParams, endpoint, flush, fs, http, log, pixel, pixelHeaders, querystring, record, reset, serialize, server, store, url;
 
   fs = require('fs');
 
@@ -25,9 +25,12 @@
     data = {
       json: JSON.stringify(store)
     };
-    store = {};
     if (config.secret) data.secret = config.secret;
     return querystring.stringify(data);
+  };
+
+  reset = function() {
+    return store = {};
   };
 
   flush = function() {
@@ -39,6 +42,7 @@
     request = endpoint.request('POST', endParams.pathname, endHeaders);
     request.write(data);
     request.on('response', function(response) {
+      reset();
       return console.info('--- flushed ---');
     });
     return request.end();
@@ -101,6 +105,7 @@
     endParams = url.parse(config.endpoint);
     endpoint = http.createClient(endParams.port || 80, endParams.hostname);
     endpoint.on('error', function(e) {
+      if (config.discard) reset();
       return console.log("--- cannot connect to endpoint : " + e.message);
     });
     endHeaders = {

--- a/src/pixel-ping.coffee
+++ b/src/pixel-ping.coffee
@@ -24,9 +24,12 @@ record = (params) ->
 # `secret` token to the request object, if configured.
 serialize = ->
   data  = json: JSON.stringify(store)
-  store = {}
   data.secret = config.secret if config.secret
   querystring.stringify data
+
+# Reset the `store`.
+reset = ->
+  store = {}
 
 # Flushes the `store` to be saved by an external API. The contents of the store
 # are sent to the configured `endpoint` URL via HTTP POST. If no `endpoint` is
@@ -39,6 +42,7 @@ flush = ->
   request = endpoint.request 'POST', endParams.pathname, endHeaders
   request.write data
   request.on 'response', (response) ->
+    reset()
     console.info '--- flushed ---'
   request.end()
 
@@ -94,6 +98,7 @@ if config.endpoint
   endParams = url.parse config.endpoint
   endpoint  = http.createClient endParams.port or 80, endParams.hostname
   endpoint.on 'error', (e) ->
+    reset() if config.discard
     console.log "--- cannot connect to endpoint : #{e.message}"
   endHeaders =
     'host':         endParams.host


### PR DESCRIPTION
`pixel-ping` isn't really nice when your endpoint is not accessible on flush, since future flushes are not made anymore. This pull-request makes it a bit more robust.
