### PR TITLE
Use max-age=0 to restrict caching.

### DIFF
--- a/lib/pixel-ping.js
+++ b/lib/pixel-ping.js
@@ -89,7 +89,7 @@
   pixel = fs.readFileSync(__dirname + '/pixel.gif');
 
   pixelHeaders = {
-    'Cache-Control': 'private, no-cache, proxy-revalidate',
+    'Cache-Control': 'private, no-cache, proxy-revalidate, max-age=0',
     'Content-Type': 'image/gif',
     'Content-Disposition': 'inline',
     'Content-Length': pixel.length

--- a/src/pixel-ping.coffee
+++ b/src/pixel-ping.coffee
@@ -81,7 +81,7 @@ pixel       = fs.readFileSync __dirname + '/pixel.gif'
 
 # HTTP headers for the pixel image.
 pixelHeaders =
-  'Cache-Control':        'private, no-cache, proxy-revalidate'
+  'Cache-Control':        'private, no-cache, proxy-revalidate, max-age=0'
   'Content-Type':         'image/gif'
   'Content-Disposition':  'inline'
   'Content-Length':       pixel.length


### PR DESCRIPTION
The previous Cache-Control header didn't prevent Chrome, at least, from
caching the pixel.gif response, which meant that statistics wouldn't get
accurately recorded.
