### PR TITLE
config.endpoint: *actually* support https endpoints

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -6,11 +6,11 @@ log = (data) ->
   print data.toString()
 
 task 'build', 'Build and watch the CoffeeScript source files', ->
-  coffee = spawn 'coffee', ['-b', '-cw', '-o', 'lib', 'src']
+  coffee = spawn 'node_modules/.bin/coffee', ['-cw', '-o', 'lib', 'src']
   coffee.stdout.on 'data', log
 
 task 'test', 'Test Pixel Ping', ->
-  coffee = spawn 'coffee', ['test/test-ping.coffee']
+  coffee = spawn 'node_modules/.bin/coffee', ['test/test-ping.coffee']
   coffee.stdout.on 'data', log
 
 task 'doc', 'Regenerate Documentation', ->

--- a/lib/pixel-ping.js
+++ b/lib/pixel-ping.js
@@ -146,7 +146,6 @@
     endParams = url.parse(config.endpoint);
     endReqOpts = {
       host: endParams.hostname,
-      port: endParams.port || 80,
       method: 'POST',
       path: endParams.pathname,
       headers: {
@@ -154,6 +153,9 @@
         'Content-Type': 'application/x-www-form-urlencoded'
       }
     };
+    if (endParams.port) {
+      endReqOpts.port = endParams.port;
+    }
   } else {
     console.warn(`No endpoint set. Hits won't be flushed, add "endpoint" to ${configPath}.`);
   }

--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
   },
   "bin":          {
     "pixel-ping": "./bin/pixel-ping"
+  },
+  "devDependencies": {
+    "cake": "^0.1.1",
+    "coffeescript": "^2.1.0"
   }
 }

--- a/src/pixel-ping.coffee
+++ b/src/pixel-ping.coffee
@@ -105,12 +105,12 @@ if config.endpoint
   endParams = url.parse config.endpoint
   endReqOpts =
     host: endParams.hostname
-    port: endParams.port or 80
     method: 'POST'
     path: endParams.pathname
     headers:
       'host':         endParams.host
       'Content-Type': 'application/x-www-form-urlencoded'
+  endReqOpts.port = endParams.port if endParams.port
 else
   console.warn "No endpoint set. Hits won't be flushed, add \"endpoint\" to #{configPath}."
 


### PR DESCRIPTION
Pull #9 added support, but was defaulting to port 80 unless
explicitly declared in the url. Now we leave off the port from the
request config unless it's returned by the url parser.

Nobody writes urls like "https://exmaple.com:443/some/url"
so let's not force them to here. The previous failure was
somewhat cryptic: "socket closed by peer" or something.

Fixes a significant bug in #9