### PR TITLE
Fix URL in README

### DIFF
--- a/README
+++ b/README
@@ -16,4 +16,4 @@
   something heavy like Google Analytics. It has no dependencies other than Node.
   
   For installation and usage instructions, see:
-  http://documentcloud.github.com/pixel-ping
+  http://documentcloud.github.io/pixel-ping


### PR DESCRIPTION
GitHub no longer redirects URLs from *.github.com to *.github.io - https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/ - so the URL provided for documentation doesn't work anymore.